### PR TITLE
make combobox customizable with theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fwego",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "author": "Ben Hansen <bnhansn@gmail.com>",
   "description": "Fwego UI",
   "repository": "loopsocial/fwego",

--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -20,6 +20,7 @@ export interface BoxProps
   alignContent?: ResponsiveString
   alignItems?: ResponsiveString
   alignSelf?: ResponsiveString
+  animation?: ResponsiveString
   as?: keyof JSX.IntrinsicElements | React.ComponentType<any>
   bg?: ResponsiveString
   backdropFilter?: ResponsiveString
@@ -74,11 +75,13 @@ export interface BoxProps
   maxHeight?: ResponsiveSpace
   maxWidth?: ResponsiveSpace
   objectFit?: ResponsiveSpace
+  opacity?: ResponsiveProp
   order?: ResponsiveProp
   outline?: ResponsiveString
   overflow?: ResponsiveOverflow
   overflowX?: ResponsiveOverflow
   overflowY?: ResponsiveOverflow
+  overflowWrap?: ResponsiveString
   p?: ResponsiveSpace
   pt?: ResponsiveSpace
   pr?: ResponsiveSpace

--- a/src/components/Box/config.ts
+++ b/src/components/Box/config.ts
@@ -17,6 +17,9 @@ const styleConfig: StyleConfig = {
   alignSelf: {
     name: 'align-self'
   },
+  animation: {
+    name: 'animation'
+  },
   backgroundImage: {
     name: 'background-image'
   },
@@ -225,6 +228,9 @@ const styleConfig: StyleConfig = {
   },
   overflowY: {
     name: 'overflow-y'
+  },
+  overflowWrap: {
+    name: 'overflow-wrap'
   },
   p: {
     name: 'padding',

--- a/src/components/Combobox/Combobox.stories.tsx
+++ b/src/components/Combobox/Combobox.stories.tsx
@@ -86,3 +86,37 @@ export const FWThemeDark: React.FC<{}> = () => {
     </FWThemeProvider>
   )
 }
+
+export const FWThemeLight: React.FC<{}> = () => {
+  return (
+    <FWThemeProvider theme="light">
+      <Combobox aria-label="hashtags">
+        <ComboboxInput placeholder="Search Hashtags" />
+        <ComboboxPopover>
+          <ComboboxList>
+            <ComboboxOption value="animals">
+              <Text color="inherit" size="small">
+                #<ComboboxOptionText />
+              </Text>
+            </ComboboxOption>
+            <ComboboxOption value="comedy">
+              <Text color="inherit" size="small">
+                #<ComboboxOptionText />
+              </Text>
+            </ComboboxOption>
+            <ComboboxOption value="gaming">
+              <Text color="inherit" size="small">
+                #<ComboboxOptionText />
+              </Text>
+            </ComboboxOption>
+            <ComboboxOption value="sports">
+              <Text color="inherit" size="small">
+                #<ComboboxOptionText />
+              </Text>
+            </ComboboxOption>
+          </ComboboxList>
+        </ComboboxPopover>
+      </Combobox>
+    </FWThemeProvider>
+  )
+}

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -14,7 +14,6 @@ import type {
 import { css } from 'emotion'
 import { Box } from '../Box/Box'
 import { Input } from '../Input/Input'
-import { useTheme } from '../../hooks'
 
 export const ComboboxInput = forwardRef(
   (
@@ -32,17 +31,14 @@ export const ComboboxPopover = forwardRef(
     props: ComboboxPopoverProps & React.HTMLAttributes<HTMLDivElement>,
     ref: React.Ref<HTMLDivElement>
   ) => {
-    const theme = useTheme()
     return (
       <Box
         as={ReachComboboxPopover}
         ref={ref}
-        bg="gray1"
-        borderRadius="12"
-        border={`1px solid ${theme.colors.gray3}`}
         overflow="hidden"
         mt="xsmall"
         py="xsmall"
+        fwelement="comboboxPopover"
         {...props}
       />
     )
@@ -64,6 +60,7 @@ export const ComboboxList = forwardRef(
         p="none"
         listStyle="none"
         userSelect="none"
+        fwelement="comboboxList"
         {...props}
       />
     )
@@ -77,7 +74,6 @@ export const ComboboxOption = forwardRef(
     props: ComboboxOptionProps & React.HTMLAttributes<HTMLLIElement>,
     ref: React.Ref<HTMLLIElement>
   ) => {
-    const theme = useTheme()
     return (
       <Box
         as={ReachComboboxOption}
@@ -85,12 +81,8 @@ export const ComboboxOption = forwardRef(
         cursor="pointer"
         px="small"
         py="xsmall"
+        fwelement="comboboxOption"
         className={css`
-          &:hover,
-          &[aria-selected='true'],
-          &[aria-selected='true']:hover {
-            background: ${theme.colors.gray2};
-          }
           [data-suggested-value] {
             font-weight: bold;
           }

--- a/src/theme/fw.ts
+++ b/src/theme/fw.ts
@@ -90,6 +90,9 @@ const fwTheme: Theme = {
   modalContent: {
     borderRadius: 6
   },
+  comboboxPopover: {
+    borderRadius: 12
+  },
   variants: {
     primary: {
       backgroundImage: colors['primaryGradient']

--- a/src/theme/fwDark.ts
+++ b/src/theme/fwDark.ts
@@ -35,6 +35,19 @@ const darkOverrides = {
   modalContent: {
     bg: colors['gray3']
   },
+  comboboxPopover: {
+    bg: colors.gray1,
+    border: `1px solid ${colors.gray3}`
+  },
+  comboboxOption: {
+    color: 'inherit',
+    '&:hover': {
+      bg: colors.gray2
+    },
+    "&[aria-selected='true']": {
+      bg: colors.gray2
+    }
+  },
   variants: {
     outline: {
       '&:hover': {

--- a/src/theme/fwLight.ts
+++ b/src/theme/fwLight.ts
@@ -29,6 +29,20 @@ const lightOverrides = {
       color: 'black'
     }
   },
+  comboboxPopover: {
+    bg: 'white',
+    border: `1px solid ${colors.gray5}`
+  },
+  comboboxOption: {
+    '&:hover': {
+      color: 'white',
+      bg: colors.primary
+    },
+    "&[aria-selected='true']": {
+      color: 'white',
+      bg: colors.primary
+    }
+  },
   variants: {
     outline: {
       color: 'black',

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -83,7 +83,7 @@ export function combineCssProperties(
   const psuedo: Array<[string, Props]> = []
   const regular: Array<[string, string]> = []
   for (const k in styleProps) {
-    if (k.match(/&:|::|:-/)) {
+    if (k.match(/&|::|:-/)) {
       psuedo.push([k, styleProps[k]])
     } else {
       regular.push([k, styleProps[k]])


### PR DESCRIPTION
https://loopsocial.github.io/fwego/?path=/story/combobox--fw-theme-light

Removed styles in Comboxbox component that were specific for dark theme. Instead added `fwelement` prop so `comboboxPopover`, `comboboxList`, and `comboboxOption` elements can be targeted with theme config.

Also modified the regex in `combineCssProperties` function to match selectors like `&[aria-selected='true']`