### PR TITLE
Add optional src to BoxProps

### DIFF
--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -108,6 +108,7 @@ export interface BoxProps
   right?: ResponsiveSize
   rowGap?: ResponsiveSpace
   size?: ResponsiveFontSize | ResponsiveSize
+  src?: string
   textAlign?: ResponsiveString
   textDecoration?: ResponsiveString
   textOverflow?: ResponsiveString


### PR DESCRIPTION
I have got this issue while trying to type a Zeffo component
`<Box as="img" src="some-path" />`

```
Type '{ as: "img"; src: string; }' is not assignable to type 'IntrinsicAttributes & BoxProps & RefAttributes<HTMLElement>'.
  Property 'src' does not exist on type 'IntrinsicAttributes & BoxProps & RefAttributes<HTMLElement>'.
```

Not sure if there is any better way